### PR TITLE
fix: add csh and tcsh scripts to the default ignore patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,13 @@
             "description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
           },
           "default": {
+            "**/*.csh": true,
+            "**/*.cshrc": true,
             "**/*.fish": true,
+            "**/*.login": true,
+            "**/*.logout": true,
+            "**/*.tcsh": true,
+            "**/*.tcshrc": true,
             "**/*.xonshrc": true,
             "**/*.xsh": true,
             "**/*.zsh": true,


### PR DESCRIPTION
Shellcheck doesn't support csh or tcsh scripts, so they should be ignored